### PR TITLE
Syntax tidy

### DIFF
--- a/pairvm
+++ b/pairvm
@@ -349,7 +349,7 @@ module PairVM
     def set_secondary
       set_role("secondary")
     end
-    
+
     def primary?
       @num < DRBD.length && /^Primary/.match(ro)
     end
@@ -479,14 +479,14 @@ module PairVM
         /^[a-z0-9\-]{3,15}$/.match(machine)
       super("/machines/#{machine}", data)
     end
-      
+ 
     def lock
       @lockfile ||= File.open("/machines/#{name}")
       raise "Machine #{name} locked" if 
         @lockfile.flock(File::LOCK_EX | File::LOCK_NB) == false &&
         !ENV['PAIRVM_IGNORE_LOCK']
     end
-    
+
     def unlock
       raise "Couldn't unlock" unless @lockfile
       @lockfile.flock(File::LOCK_UN)
@@ -612,8 +612,8 @@ module PairVM
     protected
     def drbd_net_args
       [
-      "#{Global.ips['here_drbd']}:#{drbd_port}",
-      "#{Global.ips['there_drbd']}:#{drbd_port}",
+        "#{Global.ips['here_drbd']}:#{drbd_port}",
+        "#{Global.ips['there_drbd']}:#{drbd_port}",
         "B",
         "--after-sb-0pri", "discard-zero-changes",
         "--after-sb-1pri", "consensus",
@@ -640,7 +640,7 @@ module PairVM
       find_stanza(bridge, 'netmask')
     end
 
-  private
+    private
 
     def find_stanza(bridge, stanza)
       br = stanzas(bridge)
@@ -733,12 +733,12 @@ module PairVM
         error("No such command '#{cmd}' - Try #{$0} help") unless respond_to?(cmd_sym)
         begin
           __send__(cmd_sym, *args)
-                    rescue ArgumentError => ex
+          rescue ArgumentError => ex
           # assume the user can fix these, report them nicely
           help_sym = "help_#{cmd}".to_sym
           raise unless respond_to?(help_sym)
           error(ex.to_s + " - Try #{$0} help #{cmd}", @verbose ? ex : nil)
-                    end
+        end
       end
 
       def help_help; [
@@ -783,22 +783,22 @@ module PairVM
         end
       end
 
-            def help_create; [
-            "Creates a new virtual machine",
-              ["name", "here|there|IP", "memory", "disc_size"],
-                ["ip", "bridge", "drbd_port", "kvm_options", "vnc_screen", "--no-ssh-to-peer"],
-                { "name" => "The name of the VM (15 chars max)",
-                  "here|there|IP" => "The IP of the machine to run on (or 'here' or 'there')",
-                  "memory" => "The number of megabytes of memory to allocate",
-                  "disc_size" => "The size of disc to allocate (include suffix, e.g. 50G)",
-                  "ip" => "The IP address to use (default is to auto-allocate)",
-                  "bridge" => "Ethernet bridge to use (default is br0)",
-                  "drbd_port" => "The DRBD port to use (default is to auto-allocate)",
-                  "kvm_options" => "Any permanent KVM options for this VM (default is empty)",
-                  "vnc_screen" => "The VNC screen number (default is to auto-allocate)",
-                  "--no-ssh-to-peer" => "Don't connect via SSH to peer to run the same command"
-                }
-          ]; end
+      def help_create; [
+        "Creates a new virtual machine",
+        ["name", "here|there|IP", "memory", "disc_size"],
+        ["ip", "bridge", "drbd_port", "kvm_options", "vnc_screen", "--no-ssh-to-peer"],
+        { "name" => "The name of the VM (15 chars max)",
+          "here|there|IP" => "The IP of the machine to run on (or 'here' or 'there')",
+          "memory" => "The number of megabytes of memory to allocate",
+          "disc_size" => "The size of disc to allocate (include suffix, e.g. 50G)",
+          "ip" => "The IP address to use (default is to auto-allocate)",
+          "bridge" => "Ethernet bridge to use (default is br0)",
+          "drbd_port" => "The DRBD port to use (default is to auto-allocate)",
+          "kvm_options" => "Any permanent KVM options for this VM (default is empty)",
+          "vnc_screen" => "The VNC screen number (default is to auto-allocate)",
+          "--no-ssh-to-peer" => "Don't connect via SSH to peer to run the same command"
+        }
+      ]; end
 
       def cmd_create(name, here_or_there, mem, disc_size, ip=nil, bridge=nil, drbd_port=nil, kvm_options="", vnc_screen=nil, no_ssh_to_peer=nil)
 
@@ -982,7 +982,7 @@ module PairVM
         machine.drbd_connect!
         system("ssh", Global.ips['there'], $0, "split_brain_victim", name, "0")
       end
-      
+
       def help_swaplive; [
         "Move a VM to the other server (live, doesn't move data)",
         ["name"],
@@ -1026,10 +1026,10 @@ module PairVM
           sleep 1
         end
         unless /Migration status: completed/ =~ migration_message
-           machine.kvm.monitor_cmd("cont")
-           error("KVM migration failed:\n#{migration_message}")
+          machine.kvm.monitor_cmd("cont")
+          error("KVM migration failed:\n#{migration_message}")
         end
-        
+
         cmd_stop(machine.name)
         error("Failed to enter secondary") unless machine.drbd.set_secondary
 
@@ -1044,7 +1044,7 @@ module PairVM
         (1..255).each { |fd| IO.for_fd(fd).close rescue nil }
         STDERR.reopen(File.open("/tmp/send_memory_stderr.#{name}.#{$$}", 'w'))
         exec("gzip -c | ssh #{host} cat \\\>#{machine.memory_dump_file}")
-#        exec("gzip -c >/tmp/out")
+        ##exec("gzip -c >/tmp/out")
       end
 
       def cmd_printconfig(name)
@@ -1071,11 +1071,11 @@ module PairVM
         "Starts a virtual machine running on this host",
         ["name"],
         ["--away", "--disconnected", "--kvm-options"],
-         { "name" => "The name of the VM",
-           "--away" => "Force VM to run when not on its home machine",
-         "--disconnected" => "Force VM to run without replicating to peer",
-         "--kvm-options <options...>" => "Extra KVM options for this boot"
-         }
+        { "name" => "The name of the VM",
+          "--away" => "Force VM to run when not on its home machine",
+          "--disconnected" => "Force VM to run without replicating to peer",
+          "--kvm-options <options...>" => "Extra KVM options for this boot"
+        }
       ]; end
 
       def cmd_start(name, *options)        
@@ -1106,7 +1106,7 @@ module PairVM
 
         error "#{name} is not meant to run here, you must add "+
           "'--away' to run it away from home" unless
-          machine.at_home? || away
+            machine.at_home? || away
 
         machine.drbd.setup("down")
         machine.drbd_attach! unless machine.drbd.configured?
@@ -1149,26 +1149,26 @@ module PairVM
         end
       end
 
-          def help_tap_up; [
-              "Used internally by qemu to start network interface after KVM startup",
-                    ["name"],
-                [],
-                { "name" => "The name of the VM (and network interface)" }
-              ]; end
+      def help_tap_up; [
+        "Used internally by qemu to start network interface after KVM startup",
+        ["name"],
+        [],
+        { "name" => "The name of the VM (and network interface)" }
+      ]; end
 
       def cmd_tap_up(name)
         machine = Machine.new(name)
         system "/sbin/ip link set #{name} up promisc on"
-        brctl = File.exist?('/usr/sbin/brctl') ? '/usr/sbin/brctl' : '/sbin/brctl'
-        system "#{brctl} addif #{machine.bridge} #{name}"
+        btrcl = File.exist?('/usr/sbin/brctl') ? '/usr/sbin/brctl' : '/sbin/brctl'
+        system "#{btrcl} addif #{machine.bridge} #{name}"
       end
 
-          def help_tap_down; [
-              "Used internally by qemu to stop network interface after KVM shutdown",
-                ["name"],
-                [],
-                { "name" => "The name of the VM (and network interface)" }
-          ]; end
+      def help_tap_down; [
+        "Used internally by qemu to stop network interface after KVM shutdown",
+        ["name"],
+        [],
+        { "name" => "The name of the VM (and network interface)" }
+      ]; end
 
       def cmd_tap_down(name)
         machine = Machine.new(name)
@@ -1179,14 +1179,13 @@ module PairVM
         # FIXME: this is too early, kvm needs better supervision
         machine.drbd.setup("secondary")
       end
-      
 
-            def help_drbd_connect; [
-              "Set up the DRBD for the given machine as a secondary (which can be promoted later)",
-                ["name"],
-                [],
-                { "name" => "The name of the VM" }
-            ]; end
+      def help_drbd_connect; [
+        "Set up the DRBD for the given machine as a secondary (which can be promoted later)",
+        ["name"],
+        [],
+        { "name" => "The name of the VM" }
+      ]; end
 
       def cmd_drbd_connect(name, *extra_options)
         check_system
@@ -1251,14 +1250,14 @@ module PairVM
         end
       end
 
-            def help_split_brain_victim; [
-              "Designate the VM data on this host as a 'split brain victim' and erase it to resume replication",
-                ["name"],
-                  [],
+      def help_split_brain_victim; [
+        "Designate the VM data on this host as a 'split brain victim' and erase it to resume replication",
+        ["name"],
+        [],
         { "name" => "The name of the VM" ,
-                  "snapshot_size" => "The size of the snapshot to create before erasing the data (default 2G, say '0' if you just want to erase it)"
-                }
-            ]; end
+          "snapshot_size" => "The size of the snapshot to create before erasing the data (default 2G, say '0' if you just want to erase it)"
+        }
+      ]; end
 
       def cmd_split_brain_victim(name, snapshot_size="2G")
         check_system
@@ -1279,25 +1278,24 @@ module PairVM
         verbose "Created snapshot #{lv_name}, original will now be overwritten by peer"
       end
 
-            def help_stop; [
-              "Immediately kill the given VM (power off)",
+      def help_stop; [
+        "Immediately kill the given VM (power off)",
         ["name"],
-                  [],
-                { "name" => "The name of the VM" }
-            ]; end
+        [],
+        { "name" => "The name of the VM" }
+      ]; end
 
       def cmd_stop(name)
         check_system
         Machine.new(name).kvm.stop!
       end
 
-
-            def help_autostart; [
-              "Start all VMs and DRBD connections that should run on this peer",
+      def help_autostart; [
+        "Start all VMs and DRBD connections that should run on this peer",
         [],
-                  ["names ..."],
-                { "names ..." => "Names of VMs to start automatically (default is all of them)" }
-            ]; end
+        ["names ..."],
+        { "names ..." => "Names of VMs to start automatically (default is all of them)" }
+      ]; end
 
       def cmd_autostart(*names)
         check_system
@@ -1410,7 +1408,7 @@ module PairVM
               machine.vnc_screen,
               machine.drbd.configured? ? machine.drbd.cs : "Not set up",
               machine.macaddr
-            end
+          end
         end
 
         print "\nTotal RAM here: #{Machine.total_memory_here}M "+
@@ -1424,11 +1422,11 @@ module PairVM
         ["sendto"],
         { "prefix" => "The prefix to use for statistics",
           "host" => "The hostname or IP address to which to send stats"
-         }
+        }
       ]; end
-      
+
       def cmd_graphite_stats(prefix, sendto=nil)
-        
+
         out = if sendto
           ip, port = sendto.split(":")
           port = port.to_i
@@ -1474,22 +1472,22 @@ module PairVM
       ]; end
 
       class BackupFailedException < Exception; end
-      
+
       def cmd_backup_snapshot(name, destination, speed, home_flag=false)
         home_flag = home_flag==true || home_flag=='--home'
-        
+
         machines = Machine.all.
           select { |m| m.away? || (m.at_home? && home_flag) }.
           select { |m| name == 'all' || m.name == name }
-        
+
         raise "No #{home_flag ? 'home' : 'away'} machine found '#{name}'" if
           machines.empty?
-        
+
         machines.each do |m|
           snapshot_path = m.drbd_backing_device + "_" + Time.now.to_i.to_s
           snapshot_name = snapshot_path.split("/")[-1]
           destination_host, destination_path = destination.split(":", 2)
-          
+
           begin
             raise BackupFailedException.new unless
               system "/sbin/lvcreate --size 4G --snapshot "+
@@ -1504,8 +1502,8 @@ module PairVM
                 "ssh #{destination_host} cat \\> "+
                 "#{temp_path} \\&\\& "+
                 "mv #{temp_path} #{this_destination_path}"
-              
-              size = File.open(snapshot_path, "r") do |fh| 
+
+              size = File.open(snapshot_path, "r") do |fh|
                 fh.seek(0,IO::SEEK_END); fh.tell >> 20
               end
               duration = (Time.now - started).to_i
@@ -1595,10 +1593,10 @@ HELLO
         Dir.mkdir("/machines") unless File.directory?("/machines")
         File.open("/machines/_global", "w") do |fh|
           fh.write({
-                    "drbd_ports" => "45000-46000",
-                    "ips" => ips
-                  }.
-                  to_yaml)
+            "drbd_ports" => "45000-46000",
+            "ips" => ips
+          }.
+          to_yaml)
         end
 
         error("Problem generating an SSH key for root") unless
@@ -1617,7 +1615,7 @@ HELLO
 
         error("Problem copying the SSH credentials across") unless
           Kernel::system("tar c .ssh/id_rsa .ssh/id_rsa.pub .ssh/authorized_keys "+
-                        "| ssh #{ips['there']} tar x")
+                         "| ssh #{ips['there']} tar x")
 
         print <<-DONE
 Looks good!  Now do the same on #{ips['there']}, making sure to swap
@@ -1672,7 +1670,7 @@ DONE
 
         error("#{name} is not meant to run here, you must image "+
           "it from there") unless machine.at_home?
-        
+
         kvm = machine.kvm
         error("Cannot image running VM") if kvm.running?
 
@@ -1688,7 +1686,7 @@ DONE
           # information we need is available in /etc/network/interfaces
           # or that it reflects the current network configuration. It
           # might be better to pass the netmask and gateway as arguments.
-          
+
           etc_network_interfaces = EtcNetworkInterfaces.new
           gateway = etc_network_interfaces.gateway(machine.bridge)
           netmask = etc_network_interfaces.netmask(machine.bridge)
@@ -1699,7 +1697,6 @@ DONE
           gateway = machine.ip.mask(netmask).succ.to_s unless gateway
         end
 
-        
         machine.drbd.setup("down")
         machine.drbd_attach! unless machine.drbd.configured?
         machine.drbd_connect!
@@ -1726,14 +1723,14 @@ DONE
         # Now this should work without error
         #
         machine.drbd.setup("primary")
-        
+
         options = {
-            :dist => dist,
-            :password => password,
-            :hostname => hostname,
-            :ip_address => machine.ip.to_s,
-            :ip_gateway => gateway,
-            :ip_netmask => netmask
+          :dist => dist,
+          :password => password,
+          :hostname => hostname,
+          :ip_address => machine.ip.to_s,
+          :ip_gateway => gateway,
+          :ip_netmask => netmask
         }
         if firstboot_script
           options[:firstboot_script] = begin
@@ -1751,7 +1748,7 @@ DONE
         check_system
 
         machine = Machine.new(name)
-        
+
         exit machine.digest == sum ? 0 : 1
       end
 
@@ -1792,7 +1789,6 @@ DONE
         system("/sbin/modprobe drbd") unless File.exists?("/proc/drbd")
       end
 
-
     end
   end
 end
@@ -1815,5 +1811,3 @@ else
   STDERR.print "*** pairvm does not look initialised, please run #{$0} first_time_setup\n"
   PairVM::Commands.parse(*ARGV)
 end
-
-


### PR DESCRIPTION
Some time ago Thermeon forked pairvm from Bytemark's old Mercurial repo and this fork has never been kept in sync.

Since then several improvements have been made to both repos. I have recently been working to merge Bytemark's improvements into the Thermeon repo. Now I am preparing to submit Thermeon's improvements as a series of PRs as discussed this via email with @jamielinux.

To this end I have been eliminating cosmetic discrepancies between the repos. These are mostly extraneous whitespace or poor alignment. In cases which are obviously down to stylistic preference I have updated the Thermeon fork to match Bytemark's.

This PR fixes any remaining cosmetic issues in Bytemark `pairvm`. After this PR is merged a diff of the two `pairvm`s will clearly show only the new features added to Thermeon's fork.
