### PR TITLE
Handle alternate path for brctl binary

### DIFF
--- a/pairvm
+++ b/pairvm
@@ -1172,7 +1172,8 @@ module PairVM
 
       def cmd_tap_down(name)
         machine = Machine.new(name)
-        system "/usr/sbin/brctl delif #{machine.bridge} #{name}"
+        btrcl = File.exist?('/usr/sbin/brctl') ? '/usr/sbin/brctl' : '/sbin/brctl'
+        system "#{btrcl} delif #{machine.bridge} #{name}"
         system "/sbin/ip link set #{name} down"
         # make sure the other host can become primary without a fight before
         # we switch off


### PR DESCRIPTION
Depending on the OS distro and version, the brctl binary path might be either:
- `/sbin/brctl`
- `/usr/sbin/brctl`

This PR updates `pairvm` to handle both.
